### PR TITLE
fix: update test configuration to include PYTHONPATH for QGIS

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,6 +30,6 @@ jobs:
     - uses: actions/checkout@v4
     - name: Run test latest
       run: |
-        docker run -v ${GITHUB_WORKSPACE}:/src -w /src qgis/qgis:latest sh -c 'apt-get -y update && apt-get -y install xvfb && export ORS_API_KEY=${{ secrets.ORS_API_KEY }} && apt install python3-pytest && xvfb-run -a pytest'
+        docker run -v ${GITHUB_WORKSPACE}:/src -w /src qgis/qgis:latest sh -c 'apt-get -y update && apt-get -y install xvfb && export ORS_API_KEY=${{ secrets.ORS_API_KEY }} && export PYTHONPATH=/usr/share/qgis/python && apt install python3-pytest && xvfb-run -a pytest'
       env:
         DOCKER_IMAGE: ${{ steps.docker-build.outputs.FULL_IMAGE_NAME }}


### PR DESCRIPTION
Tests on `latest` will work again.

Closes #350 