### PR TITLE
fix: specify version for ruff action in workflow configuration

### DIFF
--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -12,10 +12,10 @@ jobs:
       - uses: chartboost/ruff-action@v1
         with:
           src: ORStools
-          version: "0.13.3"
+          version: "0.14.7"
           args: format --check
       - uses: chartboost/ruff-action@v1
         with:
           src: ORStools
-          version: "0.13.3"
+          version: "0.14.7"
           args: check

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.13.3
+    rev: v0.14.7
     hooks:
       - id: ruff
         args: [--fix]


### PR DESCRIPTION
Otherwise there will be a mismatch between CI and `pre-commit` versions of ruff