### PR TITLE
fix: reset user agent correctly

### DIFF
--- a/ORStools/common/client.py
+++ b/ORStools/common/client.py
@@ -85,7 +85,7 @@ class Client(QObject):
         self.settings = QgsSettings()
         self.user_agent = self.settings.value("qgis/networkAndProxy/userAgent")
         # In case the value was still set by the ORS Tools Plugin, reset to empty string
-        if "ORStools" in self.user_agent:
+        if self.user_agent and "ORStools" in self.user_agent:
             self.user_agent = ""
         self.settings.setValue("qgis/networkAndProxy/userAgent", agent)
 
@@ -111,8 +111,6 @@ class Client(QObject):
         :rtype: QgsNetworkReplyContent
         :raises: Various ApiError exceptions based on HTTP status codes
         """
-        
-
 
         if post_json is not None:
             result = blocking_request.post(request, json.dumps(post_json).encode())
@@ -202,13 +200,11 @@ class Client(QObject):
                 # Reset to old value
                 self.settings.setValue("qgis/networkAndProxy/userAgent", self.user_agent)
 
-
         # Write env variables if successful
         if self.ENV_VARS:
             for env_var in self.ENV_VARS:
                 header_value = reply.rawHeader(self.ENV_VARS[env_var].encode()).data().decode()
                 configmanager.write_env_var(env_var, header_value)
-
 
         return json.loads(content)
 

--- a/ORStools/common/client.py
+++ b/ORStools/common/client.py
@@ -81,10 +81,12 @@ class Client(QObject):
             "Authorization": provider["key"],
         }
 
+        # Set user agent
         self.settings = QgsSettings()
-        # Read the current value
         self.user_agent = self.settings.value("qgis/networkAndProxy/userAgent")
-        # Set a new value
+        # In case the value was still set by the ORS Tools Plugin, reset to empty string
+        if "ORStools" in self.user_agent:
+            self.user_agent = ""
         self.settings.setValue("qgis/networkAndProxy/userAgent", agent)
 
         # Save some references to retrieve in client instances
@@ -109,6 +111,9 @@ class Client(QObject):
         :rtype: QgsNetworkReplyContent
         :raises: Various ApiError exceptions based on HTTP status codes
         """
+        
+
+
         if post_json is not None:
             result = blocking_request.post(request, json.dumps(post_json).encode())
         else:
@@ -193,14 +198,17 @@ class Client(QObject):
                     )
                 raise
 
+            finally:
+                # Reset to old value
+                self.settings.setValue("qgis/networkAndProxy/userAgent", self.user_agent)
+
+
         # Write env variables if successful
         if self.ENV_VARS:
             for env_var in self.ENV_VARS:
                 header_value = reply.rawHeader(self.ENV_VARS[env_var].encode()).data().decode()
                 configmanager.write_env_var(env_var, header_value)
 
-        # Reset to old value
-        self.settings.setValue("qgis/networkAndProxy/userAgent", self.user_agent)
 
         return json.loads(content)
 


### PR DESCRIPTION
If the request raises an exception, the user agent was not reset properly.
Due to the `finally`-statement, we can be sure that this definitely happens anyway.

In case an old ORStools-related user agent was still set, it is now reset to an empty string, cleaning up old mistakes.